### PR TITLE
added run_once and connection local to tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,14 +3,20 @@
 - name: Acquire IP Address
   include: acquire_ip.yml
   when: state == 'present' or state == 'acquire'
+  delegate_to: localhost
+  connection: local
+  run_once: true
 
 - name: Lookup IP Address
   include: lookup_ip.yml
   when: state == 'get' or state == 'lookup'
+  delegate_to: localhost
+  connection: local
+  run_once: true
 
 - name: Release IP Address
   include: release_ip.yml
   when: state == 'absent' or state == 'release'
-
-
-
+  delegate_to: localhost
+  connection: local
+  run_once: true


### PR DESCRIPTION
when running the role inside a playbook with multiple hosts, tasks are executed several times, failing when trying to create the record the second time